### PR TITLE
feat(relay): lock landing env toggle to NETWORK_ENV

### DIFF
--- a/packages/relay/src/views/landing/page.test.ts
+++ b/packages/relay/src/views/landing/page.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test'
+import { afterAll, describe, expect, test } from 'bun:test'
 import '@/shared/test-helpers'
 import { LandingPage } from './page'
 
@@ -26,5 +26,30 @@ describe('LandingPage', () => {
   test('includes landing-specific styles and scripts', () => {
     expect(html).toContain('Scroll reveals')
     expect(html).toContain('register-form')
+  })
+})
+
+describe('LandingPage env toggle', () => {
+  const originalEnv = process.env.NETWORK_ENV
+
+  afterAll(() => {
+    if (originalEnv === undefined) delete process.env.NETWORK_ENV
+    else process.env.NETWORK_ENV = originalEnv
+  })
+
+  test('on testnet: Mainnet radio is disabled, Testnet is checked', () => {
+    process.env.NETWORK_ENV = 'testnet'
+    const html = LandingPage()
+    expect(html).toMatch(/id="env-mainnet"[^>]*?disabled[^>]*?\/>/)
+    expect(html).toMatch(/id="env-testnet"[^>]*?checked[^>]*?\/>/)
+    expect(html).not.toMatch(/id="env-mainnet"[^>]*?checked[^>]*?\/>/)
+  })
+
+  test('on mainnet: Testnet radio is disabled, Mainnet is checked', () => {
+    process.env.NETWORK_ENV = 'mainnet'
+    const html = LandingPage()
+    expect(html).toMatch(/id="env-testnet"[^>]*?disabled[^>]*?\/>/)
+    expect(html).toMatch(/id="env-mainnet"[^>]*?checked[^>]*?\/>/)
+    expect(html).not.toMatch(/id="env-testnet"[^>]*?checked[^>]*?\/>/)
   })
 })

--- a/packages/relay/src/views/landing/page.tsx
+++ b/packages/relay/src/views/landing/page.tsx
@@ -1,8 +1,22 @@
+import { resolveNetworkEnv } from '@402md/shared/networks'
 import { Layout } from '../layout'
 import { Nav } from '../nav'
 import landingContent from './content.html' with { type: 'text' }
 import landingStyles from './styles.css' with { type: 'text' }
 import landingScript from './script.txt' with { type: 'text' }
+
+const lockEnvToggle = (html: string, env: 'mainnet' | 'testnet'): string => {
+  const disabledId = env === 'testnet' ? 'env-mainnet' : 'env-testnet'
+  const checkedId = env === 'testnet' ? 'env-testnet' : 'env-mainnet'
+  return html
+    .replace(new RegExp(`(id="${disabledId}"[^>]*?)\\s+checked`), '$1 disabled')
+    .replace(new RegExp(`(id="${disabledId}"[^>]*?)(\\s*/>)`), (match, prefix, suffix) =>
+      match.includes(' disabled') ? match : `${prefix} disabled${suffix}`,
+    )
+    .replace(new RegExp(`(id="${checkedId}"[^>]*?)(\\s*/>)`), (match, prefix, suffix) =>
+      match.includes(' checked') ? match : `${prefix} checked${suffix}`,
+    )
+}
 
 export const LandingPage = () => (
   <Layout
@@ -11,7 +25,7 @@ export const LandingPage = () => (
     extraStyles={landingStyles}
   >
     <Nav />
-    {landingContent}
+    {lockEnvToggle(landingContent, resolveNetworkEnv())}
     <script>{landingScript}</script>
   </Layout>
 )


### PR DESCRIPTION
The landing page's Mainnet/Testnet toggle was always click-able, so a user on a testnet-only relay could select Mainnet and register against addresses the relay doesn't have. Preprocess the landing HTML at render time to disable the opposite radio and pre-check the active one.